### PR TITLE
Remove std/node dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Deno module based on [crypto-random-string](https://github.com/sindresorhus/cryp
 ## Import Module
 
 ```typescript
-import { cryptoRandomString, cryptoRandomStringAsync } from "https://deno.land/x/crypto_random_string@1.0.0/mod.ts"
+import { cryptoRandomString } from "https://deno.land/x/crypto_random_string@1.0.0/mod.ts"
 // or
-import { cryptoRandomString, cryptoRandomStringAsync } from "https://github.com/piyush-bhatt/crypto-random-string/raw/main/mod.ts"
+import { cryptoRandomString } from "https://github.com/piyush-bhatt/crypto-random-string/raw/main/mod.ts"
 ```
 
 ## Usage
@@ -21,35 +21,19 @@ import { cryptoRandomString, cryptoRandomStringAsync } from "https://github.com/
 
 cryptoRandomString({length: 10}); // '0696cb9e70'
 
-await cryptoRandomStringAsync({length: 10}); // 'c8d4b0140d'
-
 cryptoRandomString({length: 10, type: 'base64'}); // 'dw3mgWC5uO'
-
-await cryptoRandomStringAsync({length: 10, type: 'base64'}); // 'k6ALljZx+E'
 
 cryptoRandomString({length: 10, type: 'url-safe'}); // '0pN1Y2Jz.X'
 
-await cryptoRandomStringAsync({length: 10, type: 'url-safe'}); // '7.F5oBY9Qy'
-
 cryptoRandomString({length: 10, type: 'numeric'}); // '1639380067'
-
-await cryptoRandomStringAsync({length: 10, type: 'numeric'}); // '0923903115'
 
 cryptoRandomString({length: 6, type: 'distinguishable'}); // 'H4HH5D'
 
-await cryptoRandomStringAsync({length: 6, type: 'distinguishable'}); // 'D2Y254'
-
 cryptoRandomString({length: 10, type: 'ascii-printable'}); // '#I&J.GP./9'
-
-await cryptoRandomStringAsync({length: 10, type: 'ascii-printable'}); // '7t%FxZkyL('
 
 cryptoRandomString({length: 10, type: 'alphanumeric'}); // 'ZtgC2J6aU5'
 
-await cryptoRandomStringAsync({length: 10, type: 'alphanumeric'}); // 'FELQVN9S8H'
-
 cryptoRandomString({length: 10, characters: 'abc'}); // 'abcabccbcc'
-
-await cryptoRandomStringAsync({length: 10, characters: 'abc'}); // 'abcbbbacbb'
 
 ```
 
@@ -59,9 +43,6 @@ await cryptoRandomStringAsync({length: 10, characters: 'abc'}); // 'abcbbbacbb'
 
 Returns a randomized string. [Hex](https://en.wikipedia.org/wiki/Hexadecimal) by default.
 
-### cryptoRandomStringAsync(options)
-
-Returns a promise which resolves to a randomized string. [Hex](https://en.wikipedia.org/wiki/Hexadecimal) by default.
 
 #### options
 

--- a/cryptoRandomString.ts
+++ b/cryptoRandomString.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "./deps.ts";
-import { promisify } from "./deps.ts";
 import {
   ALLOWED_TYPES,
   ALPHANUMERIC_CHARACTERS,
@@ -8,10 +6,51 @@ import {
   NUMERIC_CHARACTERS,
   URL_SAFE_CHARACTERS,
 } from "./constants.ts";
+import { encodeToBase64, encodeToHex } from "./deps.ts";
 
-const randomBytesAsync = promisify(randomBytes);
+export interface GenerateRandomBytes {
+  (
+    byteLength: number,
+    type: "hex" | "base64",
+    length: number,
+  ): string;
+}
 
-const generateForCustomCharacters = (length: number, characters: string[]) => {
+export interface GenerateForCustomCharacters {
+  (length: number, characters: string[]): string;
+}
+
+export const MAX_RANDOM_VALUES = 65536;
+export const MAX_SIZE = 4294967295;
+
+function randomBytes(size: number) {
+  if (size > MAX_SIZE) {
+    throw new RangeError(
+      `The value of "size" is out of range. It must be >= 0 && <= ${MAX_SIZE}. Received ${size}`,
+    );
+  }
+
+  const bytes = new Uint8Array(size);
+
+  //Work around for getRandomValues max generation
+  if (size > MAX_RANDOM_VALUES) {
+    for (let generated = 0; generated < size; generated += MAX_RANDOM_VALUES) {
+      crypto.getRandomValues(
+        bytes.subarray(generated, generated + MAX_RANDOM_VALUES),
+      );
+    }
+  } else {
+    crypto.getRandomValues(bytes);
+  }
+
+  console.log(bytes);
+  return bytes;
+}
+
+const generateForCustomCharacters: GenerateForCustomCharacters = (
+  length,
+  characters,
+) => {
   // Generating entropy is faster than complex math operations, so we use the simplest way
   const characterCount = characters.length;
   const maxValidSelector =
@@ -25,7 +64,12 @@ const generateForCustomCharacters = (length: number, characters: string[]) => {
     let entropyPosition = 0;
 
     while (entropyPosition < entropyLength && stringLength < length) {
-      const entropyValue = entropy.readUInt16LE(entropyPosition);
+      const entropyValue = new DataView(
+        entropy.buffer,
+        entropy.byteOffset,
+        entropy.byteLength,
+      )
+        .getUint16(entropyPosition, true);
       entropyPosition += 2;
       if (entropyValue > maxValidSelector) { // Skip values which will ruin distribution when using modular division
         continue;
@@ -39,55 +83,15 @@ const generateForCustomCharacters = (length: number, characters: string[]) => {
   return string;
 };
 
-const generateForCustomCharactersAsync = async (
-  length: number,
-  characters: string[],
-) => {
-  // Generating entropy is faster than complex math operations, so we use the simplest way
-  const characterCount = characters.length;
-  const maxValidSelector =
-    (Math.floor(0x10000 / characterCount) * characterCount) - 1; // Using values above this will ruin distribution when using modular division
-  const entropyLength = 2 * Math.ceil(1.1 * length); // Generating a bit more than required so chances we need more than one pass will be really low
-  let string = "";
-  let stringLength = 0;
-
-  while (stringLength < length) { // In case we had many bad values, which may happen for character sets of size above 0x8000 but close to it
-    const entropy = await randomBytesAsync(entropyLength); // eslint-disable-line no-await-in-loop
-    let entropyPosition = 0;
-
-    while (entropyPosition < entropyLength && stringLength < length) {
-      const entropyValue = entropy.readUInt16LE(entropyPosition);
-      entropyPosition += 2;
-      if (entropyValue > maxValidSelector) { // Skip values which will ruin distribution when using modular division
-        continue;
-      }
-
-      string += characters[entropyValue % characterCount];
-      stringLength++;
-    }
-  }
-
-  return string;
-};
-
-const generateRandomBytes = (
-  byteLength: number,
-  type: string,
-  length: number,
-) => randomBytes(byteLength).toString(type).slice(0, length);
-
-const generateRandomBytesAsync = async (
-  byteLength: number,
-  type: string,
-  length: number,
-) => {
-  const buffer = await randomBytesAsync(byteLength);
-  return buffer.toString(type).slice(0, length);
+const generateRandomBytes: GenerateRandomBytes = (byteLength, type, length) => {
+  const bytes = randomBytes(byteLength);
+  const str = type === "base64" ? encodeToBase64(bytes) : encodeToHex(bytes);
+  return str.slice(0, length);
 };
 
 const createGenerator = (
-  generateForCustomCharacters: Function,
-  generateRandomBytes: Function,
+  generateForCustomCharacters: GenerateForCustomCharacters,
+  generateRandomBytes: GenerateRandomBytes,
 ) =>
   (
     { length, type, characters }: {
@@ -165,9 +169,5 @@ const cryptoRandomString = createGenerator(
   generateForCustomCharacters,
   generateRandomBytes,
 );
-const cryptoRandomStringAsync = createGenerator(
-  generateForCustomCharactersAsync,
-  generateRandomBytesAsync,
-);
 
-export { cryptoRandomString, cryptoRandomStringAsync };
+export { cryptoRandomString };

--- a/cryptoRandomString.ts
+++ b/cryptoRandomString.ts
@@ -43,7 +43,6 @@ function randomBytes(size: number) {
     crypto.getRandomValues(bytes);
   }
 
-  console.log(bytes);
   return bytes;
 }
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
-export { randomBytes } from "https://deno.land/std@0.83.0/node/crypto.ts";
-export { promisify } from "https://deno.land/std@0.83.0/node/util.ts";
+export { encodeToString as encodeToHex } from "https://deno.land/std@0.99.0/encoding/hex.ts";
+export { encode as encodeToBase64 } from "https://deno.land/std@0.99.0/encoding/base64.ts";

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertMatch, assertThrows } from "./test_deps.ts";
-import { cryptoRandomString, cryptoRandomStringAsync } from "./mod.ts";
+import { cryptoRandomString } from "./mod.ts";
 
 // Probabilistic, result is always less than or equal to actual set size, chance it is less is below 1e-256 for sizes up to 32656
 const generatedCharacterSetSize = (
@@ -23,13 +23,6 @@ Deno.test("main", () => {
   assertEquals(cryptoRandomString({ length: 100 }).length, 100);
   assertMatch(cryptoRandomString({ length: 100 }), /^[a-f\d]*$/); // Sanity check, probabilistic
   assertEquals(generatedCharacterSetSize({}, 16), 16);
-});
-
-Deno.test("async", async () => {
-  assertEquals((await cryptoRandomStringAsync({ length: 0 })).length, 0);
-  assertEquals((await cryptoRandomStringAsync({ length: 10 })).length, 10);
-  assertEquals((await cryptoRandomStringAsync({ length: 100 })).length, 100);
-  assertMatch(await cryptoRandomStringAsync({ length: 100 }), /^[a-f\d]*$/);
 });
 
 Deno.test("hex", () => {


### PR DESCRIPTION
`std/node` dependency can be removed. It's slow comparing with Native implementation.

Also async api removed. because Deno doesn't offer async api to get crypto random values yet. `std/node` async api is just a polyfill via `setTimeout` 